### PR TITLE
feat(types): inherit config properties from axios types

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, ReactChildren, ReactChild } from 'react';
-import axios from 'axios';
+import axios, { AxiosRequestConfig } from 'axios';
 import isOnline from 'is-online';
 // @ts-ignore
 import root from 'window-or-global';
@@ -7,7 +7,7 @@ import root from 'window-or-global';
 interface Props {
   children: ReactChild | ReactChildren;
   skip: boolean,
-  config: object,
+  config: AxiosRequestConfig,
 }
 
 export default (


### PR DESCRIPTION
Hi.
I just fixed a little thing to get more advantage of typescript. Since `config` property is a instance of axios request config, so we can easily use the axios types for that.

Comments are welcome.